### PR TITLE
Notebook Updation & tuning_size Param Remove from Model Tuning

### DIFF
--- a/flexml/structures/supervised_base.py
+++ b/flexml/structures/supervised_base.py
@@ -541,7 +541,6 @@ class SupervisedBase:
     def tune_model(self, 
                    model: Optional[object] = None,
                    tuning_method: Optional[str] = 'randomized_search',
-                   tuning_size: Optional[str] = 'wide',
                    eval_metric: Optional[str] = None,
                    param_grid: Optional[dict] = None,
                    n_iter: int = 10,
@@ -564,14 +563,6 @@ class SupervisedBase:
             * 'randomized_search' for RandomizedSearchCV (https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.RandomizedSearchCV.html)
             
             * 'optuna' for Optuna (https://optuna.readthedocs.io/en/stable/)
-
-        tuning_size: str (default = 'wide')
-            The size of the tuning process. It can be 'quick' or 'wide'
-
-            * If 'quick' is selected, number of params or number of values in the each params will be decrased.
-                -> For detailed information, visit flexml/_model_tuner.py/_param_grid_validator() function's doc
-
-            * If 'wide' is selected, param_grid will stay same
 
         eval_metric : str (default='r2' for regression, 'accuracy' for classification)
             The evaluation metric to use for model evaluation
@@ -612,7 +603,7 @@ class SupervisedBase:
             self.tuned_model = tuning_report['tuned_model']
             self.tuned_model_score = tuning_report['tuned_model_score']
             tuned_time_taken = tuning_report['time_taken_sec']
-            tuned_model_name = f"{self.tuned_model.__class__.__name__}_({tuning_report['tuning_method']}({tuning_size}))_(cv={tuning_report['cv']})_(n_iter={tuning_report['n_iter']})"
+            tuned_model_name = f"{self.tuned_model.__class__.__name__}_({tuning_report['tuning_method']})_(cv={tuning_report['cv']})_(n_iter={tuning_report['n_iter']})"
 
             # Add the tuned model and it's score to the model_training_info list
             model_perf = self.__evaluate_model_perf(self.y_test, self.tuned_model.predict(self.X_test))
@@ -654,12 +645,11 @@ class SupervisedBase:
             cv = 2
             self.__logger.info(info_msg)
 
-        self.__logger.info("[PROCESS] Model Tuning process is started")
+        self.__logger.info(f"[PROCESS] Model Tuning process is started with '{tuning_method}' method")
         tuning_method = tuning_method.lower()
         if tuning_method == "grid_search":
             tuning_result = self.model_tuner.grid_search(
                 model=model,
-                tuning_size=tuning_size,
                 param_grid=param_grid,
                 eval_metric=eval_metric,
                 cv=cv,
@@ -670,7 +660,6 @@ class SupervisedBase:
         elif tuning_method == "randomized_search":
             tuning_result = self.model_tuner.random_search(
                 model=model,
-                tuning_size=tuning_size,
                 param_grid=param_grid,
                 eval_metric=eval_metric,
                 n_iter=n_iter,
@@ -682,7 +671,6 @@ class SupervisedBase:
         elif tuning_method == "optuna":
             tuning_result = self.model_tuner.optuna_search(
                 model=model,
-                tuning_size=tuning_size,
                 param_grid=param_grid,
                 eval_metric=eval_metric,
                 n_iter=n_iter,

--- a/notebooks/classification_experiment.ipynb
+++ b/notebooks/classification_experiment.ipynb
@@ -404,10 +404,9 @@
     "* experiment_size: default is quick, quick (uses almost half amount of the available ml models), wide (Uses all available ml models)\n",
     "* test_size: default is 0.25\n",
     "* eval_metric: default is \"accuracy\", other options are \"precision\", \"recall\", \"f1_score\"\n",
-    "* random_state: default is 42\n",
     "\"\"\"\n",
-    "classification_exp = Classification(data=df, target_col=\"target\")\n",
-    "classification_exp.start_experiment(experiment_size=\"quick\", test_size=0.25, eval_metric=\"accuracy\", random_state=42)"
+    "classification_exp = Classification(data=df, target_col=\"target\", experiment_size=\"quick\", test_size=0.25)\n",
+    "classification_exp.start_experiment(eval_metric=\"accuracy\")"
    ]
   },
   {

--- a/notebooks/regression_experiment.ipynb
+++ b/notebooks/regression_experiment.ipynb
@@ -286,10 +286,9 @@
     "* experiment_size: default is quick, quick (uses almost half amount of the available ml models), wide (Uses all available ml models)\n",
     "* test_size: default is 0.25\n",
     "* eval_metric: default is \"r2\", other options are \"mae\", \"mse\", \"rmse\"\n",
-    "* random_state: default is 42\n",
     "\"\"\"\n",
-    "reg_exp = Regression(data=df, target_col=\"MedHouseVal\")\n",
-    "reg_exp.start_experiment(experiment_size=\"wide\", test_size=0.25, eval_metric=\"rmse\", random_state=42)"
+    "reg_exp = Regression(data=df, target_col=\"MedHouseVal\", experiment_size=\"quick\", test_size=0.25)\n",
+    "reg_exp.start_experiment(eval_metric=\"rmse\")"
    ]
   },
   {

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -55,7 +55,7 @@ class TestClassification(unittest.TestCase):
             tuning_methods = ["randomized_search", "optuna"]
 
             for method in tuning_methods:
-                classification_exp.tune_model(n_iter=3, cv = None, tuning_size=exp_size)
+                classification_exp.tune_model(n_iter=3, cv = 2)
 
                 if classification_exp.tuned_model is None:
                     error_msg = f"An error occured while tuning the model with {method} in {exp_size} classification, tuned model is None"

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -52,7 +52,6 @@ class TestMLModels(unittest.TestCase):
             self.reg_exp.tune_model(
                 model=model,
                 tuning_method="randomized_search",
-                tuning_size='wide',
                 param_grid=model_tuning_params,
                 n_iter=3,
                 cv=None,
@@ -82,10 +81,9 @@ class TestMLModels(unittest.TestCase):
             self.classification_exp.tune_model(
                 model=model,
                 tuning_method="randomized_search",
-                tuning_size='wide',
                 param_grid=model_tuning_params,
                 n_iter=3,
-                cv=None,
+                cv=2,
                 n_jobs=-1
             )
         except Exception as e:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -54,7 +54,7 @@ class TestRegression(unittest.TestCase):
             tuning_methods = ["randomized_search", "optuna"]
 
             for method in tuning_methods:
-                reg_exp.tune_model(n_iter=3, cv = None, tuning_size=exp_size)
+                reg_exp.tune_model(n_iter=3, cv = 2)
 
                 if reg_exp.tuned_model is None:
                     error_msg = f"An error occured while tuning the model with {method} in {exp_size} regression, tuned model is None"


### PR DESCRIPTION
Explanation:
* Reverted the updates made on the notebooks since they should be updated only when a new release is made [#1d4d96c](https://github.com/ozguraslank/flexml/commit/1d4d96c5a4463a99bab5944bf5f88a90919cf1ac)

* Removed tuning_size param from model tuning because Its basically the same idea on GridSearch & RandomizedSearch. So Its not necessary to serve it in the library [#00d97fa](https://github.com/ozguraslank/flexml/pull/10/commits/00d97fafd0134b960ace5638197e3ebe54aab230)
