### PR TITLE
Float rounds are adjusted & case sensitivity in eval metrics is removed

### DIFF
--- a/flexml/_model_tuner.py
+++ b/flexml/_model_tuner.py
@@ -202,19 +202,19 @@ class ModelTuner:
         eval_metric = eval_metric.lower()
         
         if eval_metric == 'r2':
-            return r2_score(self.y_test, model.predict(self.X_test))
+            return round(r2_score(self.y_test, model.predict(self.X_test)), 6)
         elif eval_metric == 'mae':
-            return mean_absolute_error(self.y_test, model.predict(self.X_test))
+            return round(mean_absolute_error(self.y_test, model.predict(self.X_test)), 6)
         elif eval_metric == 'mse':
-            return mean_squared_error(self.y_test, model.predict(self.X_test))
+            return round(mean_squared_error(self.y_test, model.predict(self.X_test)), 6)
         elif eval_metric == 'accuracy':
-            return accuracy_score(self.y_test, model.predict(self.X_test))
+            return round(accuracy_score(self.y_test, model.predict(self.X_test)), 6)
         elif eval_metric == 'precision':
-            return precision_score(self.y_test, model.predict(self.X_test))
+            return round(precision_score(self.y_test, model.predict(self.X_test)), 6)
         elif eval_metric == 'recall':
-            return recall_score(self.y_test, model.predict(self.X_test))
+            return round(recall_score(self.y_test, model.predict(self.X_test)), 6)
         elif eval_metric == 'f1':
-            return f1_score(self.y_test, model.predict(self.X_test))
+            return round(f1_score(self.y_test, model.predict(self.X_test)), 6)
         else:
             error_msg = "Error while evaluating the current model during the model tuning process. The eval_metric should be one of the following: 'r2', 'mae', 'mse', 'accuracy', 'precision', 'recall', 'f1'"
             self.logger.error(error_msg)
@@ -526,7 +526,7 @@ class ModelTuner:
             
             # Update the best score and best hyperparameters If the current score is better than the best one
             if model_stats['tuned_model_score'] is None or score > model_stats['tuned_model_score']:
-                model_stats['tuned_model_score'] = round(score, 4)
+                model_stats['tuned_model_score'] = round(score, 6)
                 model_stats['tuned_model'] = test_model
 
             return score

--- a/flexml/config/supervised_config.py
+++ b/flexml/config/supervised_config.py
@@ -11,9 +11,9 @@ ML_MODELS = {
 
 # Regression & Classification Evaluation Metrics
 EVALUATION_METRICS = {
-    "Regression": {"DEFAULT": "r2",
-                   "ALL": ["r2", "mae", "mse", "rmse"]},
+    "Regression": {"DEFAULT": "R2",
+                   "ALL": ["R2", "MAE", "MSE", "RMSE"]},
                    
-    "Classification": {"DEFAULT": "accuracy",
-                       "ALL": ["accuracy", "precision", "recall", "f1_score"]}
+    "Classification": {"DEFAULT": "Accuracy",
+                       "ALL": ["Accuracy", "Precision", "Recall", "F1 Score"]}
 }

--- a/flexml/structures/supervised_base.py
+++ b/flexml/structures/supervised_base.py
@@ -188,7 +188,9 @@ class SupervisedBase:
             self.__logger.error(error_msg)
             raise ValueError(error_msg)
         
-        if eval_metric not in self.__ALL_EVALUATION_METRICS:
+        if ((self.__ML_TASK_TYPE == "Classification" and eval_metric.lower().capitalize() not in self.__ALL_EVALUATION_METRICS) or
+                (self.__ML_TASK_TYPE == "Regression" and eval_metric.upper() not in self.__ALL_EVALUATION_METRICS)):
+
             error_msg = f"{eval_metric} is not a valid evaluation metric for {self.__ML_TASK_TYPE}, expected one of the following: {self.__ALL_EVALUATION_METRICS}"
             self.__logger.error(error_msg)
             raise ValueError(error_msg)
@@ -237,10 +239,10 @@ class SupervisedBase:
         """
 
         if self.__ML_TASK_TYPE == "Regression":
-            r2 = round(r2_score(y_test, y_pred), 4)
-            mae = round(mean_absolute_error(y_test, y_pred), 4)
-            mse = round(mean_squared_error(y_test, y_pred), 4)
-            rmse = round(np.sqrt(mse), 4)
+            r2 = round(r2_score(y_test, y_pred), 6)
+            mae = round(mean_absolute_error(y_test, y_pred), 6)
+            mse = round(mean_squared_error(y_test, y_pred), 6)
+            rmse = round(np.sqrt(mse), 6)
             return {
                 "r2": r2,
                 "mae": mae,
@@ -249,10 +251,10 @@ class SupervisedBase:
             }
         
         elif self.__ML_TASK_TYPE == "Classification":
-            accuracy = round(accuracy_score(y_test, y_pred), 4)
-            precision = round(precision_score(y_test, y_pred, average='weighted'), 4)
-            recall = round(recall_score(y_test, y_pred, average='weighted'), 4)
-            f1 = round(f1_score(y_test, y_pred, average='weighted'), 4)
+            accuracy = round(accuracy_score(y_test, y_pred), 6)
+            precision = round(precision_score(y_test, y_pred, average='weighted'), 6)
+            recall = round(recall_score(y_test, y_pred, average='weighted'), 6)
+            f1 = round(f1_score(y_test, y_pred, average='weighted'), 6)
             return {
                 "accuracy": accuracy,
                 "precision": precision,


### PR DESCRIPTION
**Explanation**

* Rounding the float metrics changed from 4 to 6 [#8e30c5a](https://github.com/ozguraslank/flexml/commit/8e30c5a3635b04558d7db3934ecaaa6af0fb0dd2)

* Case sensitivity in eval metrics is removed. e.g. Typing 'RMSE' instead of 'rmse' or 'Accuracy' instead of 'accuracy' would raise error [#8e30c5a](https://github.com/ozguraslank/flexml/commit/8e30c5a3635b04558d7db3934ecaaa6af0fb0dd2)