### PR TITLE
Error Fix / Eval Metrics Case handling, 'average' param configuration / Added predict_proba() function

### DIFF
--- a/tests/test_supervised.py
+++ b/tests/test_supervised.py
@@ -176,19 +176,21 @@ class TestRegression(unittest.TestCase):
 
     def test_04_predict_model(self):
         # Setup for Classification experiment
-        exp_obj = self.test_config['Regression']['exp_obj']
+        exp_obj = self.test_config['Classification']['exp_obj']
         
         # Thanks to function naming, test_01_supervised will run first and exp_obj will be created --
         # But let's check it in just case and create a new experiment object if it's None
         if exp_obj is None:
-            df = self.test_config['Regression'].get('data')
-            target_col = self.test_config['Regression'].get('target_col')
+            df = self.test_config['Classification'].get('data')
+            target_col = self.test_config['Classification'].get('target_col')
 
-            exp_obj = Regression(
+            exp_obj = Classification(
                 data = df,
                 target_col = target_col
             ).start_experiment()
 
         # Make predictions
-        predictions = exp_obj.predict(self.test_config['Regression'].get('data').drop(columns=['target']), full_train=False)
+        predictions = exp_obj.predict(self.test_config['Classification'].get('data').drop(columns=['target']), full_train=False)
+        predictions_probabilities = exp_obj.predict_proba(self.test_config['Classification'].get('data').drop(columns=['target']), full_train=False)
         self.assertIsInstance(predictions, np.ndarray)
+        self.assertIsInstance(predictions_probabilities, np.ndarray)


### PR DESCRIPTION
* When ROC-AUC or F1 Score is selected as an `eval_metric` in `start_experiment()`, FlexML raise error because of wrong case handling.
Fixed by adding advanced case handling via `re` library [#ad1d1f7](https://github.com/ozguraslank/flexml/commit/ad1d1f7a99efdcbd6198d21e5cf5b03e3bdef2fa)

* Recall, precision, f1-score and ROC-AUC was raising error when multiclass classification is used since their `average` param is set to default, which is `binary`
Fixed by n_class finder in `y_test`, `binary` If two classes, `macro` if more [#03cfbdc](https://github.com/ozguraslank/flexml/commit/03cfbdc3b3b574f1d3f22754f48c4682933db34e)

---
<b>Feature Addition</b>
`predict_proba()` function is added and predict unittest in `test_supervised.py` is revised accordingly [#5aaf0b3
](https://github.com/ozguraslank/flexml/commit/5aaf0b349909024741126cccdf34b461a3eb654a)
