### PR TITLE
Error Fix and Improvement on Optuna and General Tuning Processes

### DIFF
--- a/flexml/_model_tuner.py
+++ b/flexml/_model_tuner.py
@@ -493,7 +493,9 @@ class ModelTuner:
         def objective(trial):
             try:
                 # Generate parameters for the trial
-                params = {}
+                current_model = pipeline.named_steps['model']
+                params = current_model.get_params()
+
                 for param_name, param_values in param_grid.items():
                     first_element = param_values[0]
 
@@ -508,7 +510,7 @@ class ModelTuner:
                         self.logger.info(info_msg)
 
                 # Extract the model from the pipeline
-                test_model = type(pipeline.named_steps['model'])()
+                test_model = type(current_model)()
                 test_model.set_params(**params)
 
                 # Decompose the pipeline by removing the model from it to use it for only feature engineering

--- a/flexml/config/ml_models.py
+++ b/flexml/config/ml_models.py
@@ -1,11 +1,11 @@
-from sklearn.linear_model import LinearRegression, LogisticRegression, ElasticNet, HuberRegressor, Lasso, Ridge, BayesianRidge, OrthogonalMatchingPursuit, Perceptron, PassiveAggressiveClassifier, SGDRegressor, RidgeClassifier
+from sklearn.linear_model import LinearRegression, LogisticRegression, ElasticNet, HuberRegressor, Lasso, Ridge, BayesianRidge, OrthogonalMatchingPursuit, RidgeClassifier
 from sklearn.tree import DecisionTreeRegressor, DecisionTreeClassifier
 from sklearn.ensemble import (
     AdaBoostRegressor, AdaBoostClassifier, GradientBoostingRegressor, GradientBoostingClassifier, 
     RandomForestRegressor, RandomForestClassifier, ExtraTreesRegressor, ExtraTreesClassifier, HistGradientBoostingRegressor,
     HistGradientBoostingClassifier
 )
-from sklearn.neighbors import KNeighborsRegressor, KNeighborsClassifier, NearestCentroid
+from sklearn.neighbors import KNeighborsRegressor, KNeighborsClassifier
 from sklearn.naive_bayes import GaussianNB
 from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis, LinearDiscriminantAnalysis
 from sklearn.neural_network import MLPRegressor, MLPClassifier
@@ -48,7 +48,6 @@ def get_ml_models(num_class: Optional[int] = None):
     GRADIENT_BOOSTING_REGRESSION = GradientBoostingRegressor()
     ELASTIC_NET_REGRESSION = ElasticNet()
     HUBER_REGRESSION = HuberRegressor()
-    SGD_REGRESSION = SGDRegressor()
     KNN_REGRESSION = KNeighborsRegressor() 
 
     # Wide Regression Models
@@ -84,15 +83,12 @@ def get_ml_models(num_class: Optional[int] = None):
     EXTRA_TREES_CLASSIFIER = ExtraTreesClassifier()
     QDA_CLASSIFIER = QuadraticDiscriminantAnalysis()
     LDA_CLASSIFIER = LinearDiscriminantAnalysis()
-    PERCEPTRON_CLASSIFIER = Perceptron()
-    PASSIVE_AGGRESSIVE_CLASSIFIER = PassiveAggressiveClassifier()
     MLP_CLASSIFIER = MLPClassifier(
         hidden_layer_sizes=(100,),
         early_stopping=True,
         tol=0.001,
         learning_rate='adaptive'
     )
-    NEAREST_CENTROID_CLASSIFIER = NearestCentroid()
 
     # Quick Regression Model Configurations
     QUICK_REGRESSION_MODELS = [
@@ -183,17 +179,6 @@ def get_ml_models(num_class: Optional[int] = None):
             "tuning_param_grid": {
                 "epsilon": [1.1, 1.35, 1.5, 1.75, 2.0],
                 "alpha": [0.0001, 0.001, 0.01, 0.1, 1.0]
-            }
-        },
-        {
-            "name": SGD_REGRESSION.__class__.__name__,
-            "model": SGD_REGRESSION,
-            "tuning_param_grid": {
-                "loss": ["squared_error", "huber", "epsilon_insensitive"],
-                "alpha": [0.0001, 0.001, 0.01, 0.1],
-                "learning_rate": ["optimal", "adaptive"],
-                "max_iter": [1000, 2000],
-                "tol": [1e-3, 1e-4]
             }
         },
         {
@@ -464,37 +449,6 @@ def get_ml_models(num_class: Optional[int] = None):
             }
         },
         {
-            "name": PERCEPTRON_CLASSIFIER.__class__.__name__,
-            "model": PERCEPTRON_CLASSIFIER,
-            "tuning_param_grid": {
-                "penalty": ["l2", "l1", "elasticnet"],
-                "alpha": [0.0001, 0.001, 0.01, 0.1],
-                "max_iter": [1000, 2000, 3000],
-                "tol": [1e-3, 1e-4, 1e-5],
-                "shuffle": [True, False],
-                "eta0": [1.0, 0.1, 0.01],
-                "early_stopping": [True, False],
-                "validation_fraction": [0.1, 0.2, 0.3],
-                "n_iter_no_change": [5, 10, 15]
-            }
-        },
-        {
-            "name": PASSIVE_AGGRESSIVE_CLASSIFIER.__class__.__name__,
-            "model": PASSIVE_AGGRESSIVE_CLASSIFIER,
-            "tuning_param_grid": {
-                "C": [0.1, 1.0, 10.0],
-                "fit_intercept": [True, False],
-                "max_iter": [1000, 2000, 3000],
-                "tol": [1e-3, 1e-4, 1e-5],
-                "early_stopping": [True, False],
-                "validation_fraction": [0.1, 0.2, 0.3],
-                "n_iter_no_change": [5, 10, 15],
-                "shuffle": [True, False],
-                "loss": ["hinge", "squared_hinge"],
-                "average": [True, False]
-            }
-        },
-        {
             "name": MLP_CLASSIFIER.__class__.__name__,
             "model": MLP_CLASSIFIER,
             "tuning_param_grid": {
@@ -504,14 +458,6 @@ def get_ml_models(num_class: Optional[int] = None):
                 "alpha": [0.0001, 0.001, 0.01],
                 "learning_rate": ["constant", "adaptive"],
                 "learning_rate_init": [0.001, 0.01]
-            }
-        },
-        {
-            "name": NEAREST_CENTROID_CLASSIFIER.__class__.__name__,
-            "model": NEAREST_CENTROID_CLASSIFIER,
-            "tuning_param_grid": {
-                "metric": ["euclidean", "manhattan", "cosine"],
-                "shrink_threshold": [0.1, 0.5, 1.0]
             }
         }
     ]

--- a/flexml/config/ml_models.py
+++ b/flexml/config/ml_models.py
@@ -274,7 +274,7 @@ def get_ml_models(num_class: Optional[int] = None):
             "name": OMP_REGRESSION.__class__.__name__,
             "model": OMP_REGRESSION,
             "tuning_param_grid": {
-                "n_nonzero_coefs": [None, 5, 10, 15, 20],
+                "n_nonzero_coefs": [5, 10, 15, 20],
                 "tol": [1e-4, 1e-3, 1e-2, 1e-1]
             }
         },
@@ -460,14 +460,14 @@ def get_ml_models(num_class: Optional[int] = None):
             "model": LDA_CLASSIFIER,
             "tuning_param_grid": {
                 "solver": ["svd", "lsqr", "eigen"],
-                "shrinkage": [None, "auto", 0.1, 0.5, 1.0]
+                "shrinkage": [0.1, 0.5, 1.0]
             }
         },
         {
             "name": PERCEPTRON_CLASSIFIER.__class__.__name__,
             "model": PERCEPTRON_CLASSIFIER,
             "tuning_param_grid": {
-                "penalty": [None, "l2", "l1", "elasticnet"],
+                "penalty": ["l2", "l1", "elasticnet"],
                 "alpha": [0.0001, 0.001, 0.01, 0.1],
                 "max_iter": [1000, 2000, 3000],
                 "tol": [1e-3, 1e-4, 1e-5],
@@ -511,7 +511,7 @@ def get_ml_models(num_class: Optional[int] = None):
             "model": NEAREST_CENTROID_CLASSIFIER,
             "tuning_param_grid": {
                 "metric": ["euclidean", "manhattan", "cosine"],
-                "shrink_threshold": [None, 0.1, 0.5, 1.0]
+                "shrink_threshold": [0.1, 0.5, 1.0]
             }
         }
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pandas>=2.0.1
 scikit-learn>=1.5.0,<=1.5.2
 xgboost>=2.0.0
 lightgbm>=4.0.0
-catboost>=1.2.3
+catboost>=1.2.5
 tqdm>=4.60.0
 optuna>=3.0.0  
 ipython>=7.11.0


### PR DESCRIPTION
### Explanation

* Catboost raises error in Optuna if parallel computing is enabled (n_jobs > 1), [this issue ](https://github.com/catboost/catboost/issues/2620)is fixed at 1.2.5, adjusted flexml's minimum catboost requirement as 1.2.5 or higher [#90bbf05](https://github.com/ozguraslank/flexml/commit/90bbf055ccbf493d39a7882d8d4532d4318d3939)

* Revised value lists with mixed data types in tuning_param_grid dictionaries. Set them to be only one data type to avoid any conflicts during Optuna tuning [#3206fc8](https://github.com/ozguraslank/flexml/commit/3206fc8320673e1f6644ef88e48a15f1c693802e)

* In order to save current params of the model used in optuna_search, the model is taken from pipeline instead of re-creating it from 0 via type() function. [#ed85ed3](https://github.com/ozguraslank/flexml/commit/ed85ed3fe5d2236a3b50b2fe2dc2a71542ef813c)

* Removed classification models that don't support predict_proba, since we need it for ROC-AUC calculation [#851c912](https://github.com/ozguraslank/flexml/commit/851c9126f20e93edf92c5df6ef51c0c714e04422)

--------
#### FlexML's tuning module had critical issues when dealing with multi-class classification problems [#a6600ac](https://github.com/ozguraslank/flexml/commit/a6600aca833a21be3cf5d50a4ce6ebbde13b44ca)

* Revised grid_search and randomized_search's scoring dictionaries to suitable ones by looking at to y to check If Its binary or multi-class problem.
* y is sent as encoded to ModelTuner() class's initilization at supervised_base.py so that grid_search and randomized_search won't be broken since we only send pipeline object to here that processes X only.
* for optuna, feature_engineer object will be sent with model together to help feature engineering process