### PR TITLE
Revised test_ml_models unittest and removed unnecessary model import in ml_models

### DIFF
--- a/flexml/config/ml_models.py
+++ b/flexml/config/ml_models.py
@@ -1,4 +1,4 @@
-from sklearn.linear_model import LinearRegression, LogisticRegression, ElasticNet, HuberRegressor, Lasso, Ridge, BayesianRidge, OrthogonalMatchingPursuit, RidgeClassifier
+from sklearn.linear_model import LinearRegression, LogisticRegression, ElasticNet, HuberRegressor, Lasso, Ridge, BayesianRidge, OrthogonalMatchingPursuit
 from sklearn.tree import DecisionTreeRegressor, DecisionTreeClassifier
 from sklearn.ensemble import (
     AdaBoostRegressor, AdaBoostClassifier, GradientBoostingRegressor, GradientBoostingClassifier, 

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -64,6 +64,12 @@ class TestMLModels(unittest.TestCase):
             
             model.fit(X_train, y_train)
 
+            # If its classification problem
+            if objective == 'Classification':
+                model.predict_proba(X_train)
+            else:
+                model.predict(X_train)
+
         except Exception as e:
             error_msg = f"An error occurred while fitting {model_name} model. Error: {e}"
             self.logger.error(error_msg)


### PR DESCRIPTION
### Explanation

* Revised `test_ml_models.py` unittest to use `predict_proba()` in classification models since FlexML uses `predict_proba() `function in classification models [#4fe267c](https://github.com/ozguraslank/flexml/commit/4fe267cce25995ae50819f2d99f906323670b3be)
* Removed unused model `RidgeClassifier` import in `ml_models.py` [#c34925a](https://github.com/ozguraslank/flexml/commit/c34925a242f9e49bc30e8bc18aa632cc72ae1100)