### PR TITLE
Error fix and improvement at model evaluation

### DIFF
--- a/flexml/_model_tuner.py
+++ b/flexml/_model_tuner.py
@@ -502,7 +502,7 @@ class ModelTuner:
         elif verbose == 4:
             optuna.logging.set_verbosity(optuna.logging.DEBUG)
 
-        study_direction = "maximize" if eval_metric in ['R2', 'Accuracy', 'Precision', 'Recall', 'F1 Score'] else "minimize"
+        study_direction = "maximize" if eval_metric in ['R2', 'Accuracy', 'Precision', 'Recall', 'F1 Score', 'ROC-AUC'] else "minimize"
 
         def objective(trial):
             # Generate parameters for the trial

--- a/flexml/helpers/supervised_helpers.py
+++ b/flexml/helpers/supervised_helpers.py
@@ -12,6 +12,27 @@ from sklearn.metrics import (
     f1_score,
     roc_auc_score)
 
+
+def _safe_mape(y_true: Union[pd.Series, np.ndarray], y_pred: Union[pd.Series, np.ndarray]) -> float:
+    """
+    Computes the Mean Absolute Percentage Error (MAPE) while ignoring zero values in y_true since MAPE is undefined for zero values.
+
+    Parameters
+    ----------
+    y_true : pd.Series or np.ndarray
+        The actual values of the target column
+
+    y_pred : pd.Series or np.ndarray
+        The predicted values of the target column
+
+    Returns
+    -------
+    float
+        The MAPE score for the desired eval metric
+    """
+    mask = y_true != 0  # Ignore zero values in y_true
+    return round(np.mean(np.abs((y_true[mask] - y_pred[mask]) / y_true[mask])), 6)
+
 def _evaluate_preds(
     y_true: Union[pd.Series, np.ndarray],
     y_pred: Union[pd.Series, np.ndarray],
@@ -52,7 +73,7 @@ def _evaluate_preds(
     elif eval_metric == 'RMSE':
         return round(np.sqrt(mean_squared_error(y_true, y_pred)), 6)
     elif eval_metric == 'MAPE':
-        return round(np.mean(np.abs((y_true - y_pred) / y_true)) * 100, 6)
+        return _safe_mape(y_true, y_pred)
     elif eval_metric == 'Accuracy':
         return round(accuracy_score(y_true, y_pred), 6)
     elif eval_metric == 'Precision':

--- a/flexml/structures/supervised_base.py
+++ b/flexml/structures/supervised_base.py
@@ -859,9 +859,12 @@ class SupervisedBase:
             if s.name in ['MAE', 'MSE', 'RMSE', 'MAPE']:
                 s_nonneg = s.where(s >= 0, np.nan)
                 best_val = s_nonneg.min()
-                is_best = s == best_val
+                if best_val == float('inf'):
+                    is_best = pd.Series([False] * len(s))
+                else:
+                    is_best = (s == best_val) & (s != float('inf')) & (s != -1)
             else:
-                is_best = s == s.max()
+                is_best = (s == s.max()) & (s != float('inf')) & (s != -1)
             return ['background-color: green' if v else '' for v in is_best]
         
         eval_metric = eval_metric_checker(self.__ML_TASK_TYPE, eval_metric)


### PR DESCRIPTION
### Explanation

* Mistake fix / 'ROC-AUC' condition is added to optuna's `study_direction` finding line [#fdcfaf8](https://github.com/ozguraslank/flexml/commit/fdcfaf8e1d278b10a9e3bece0899c2b315b27d66)
* Revised `show_model_stats()` to avoid wrong highlights by filtering `float('inf')` and -1 values (They are coming from model evaluation, indicates error) [#dfbdb1](https://github.com/ozguraslank/flexml/commit/dfbdb1287b1c16244ffcefb11a4f1cf90e5d82fe)
* Error fix at `MAPE` calculation: Since `MAPE` occurs `float('inf')` when `y_true` has 0 values, created a new mape calculator function called `_safe_mape()` that filters 0 values first [#50bf9bd](https://github.com/ozguraslank/flexml/commit/50bf9bd6dd4ea46ab0b673b4f3315345fad9dca6)