### PR TITLE
Forced root logger to be overwritten by flexml

### DIFF
--- a/flexml/logger/logger.py
+++ b/flexml/logger/logger.py
@@ -34,7 +34,8 @@ def _logger_configuration(log_level: str, logging_to_file: bool = False):
         level="INFO",
         format=log_format,
         datefmt="%Y-%m-%d %H:%M:%S",
-        handlers=handlers
+        handlers=handlers,
+        force=True
     )
 
 def get_logger(


### PR DESCRIPTION
### Explanation

Warning and info messages from loggers weren't seen in Google Colab and Kaggle notebooks during FlexML's new release tests via test pypi, overriding the root logger by `force=True` param solved the issue [#7490311](https://github.com/ozguraslank/flexml/commit/7490311fd893f366c56e70423c04f22b6e830fef)