### PR TITLE
Bug fix / Added 'MAPE' to reverse_signed_eval_metrics

### DIFF
--- a/flexml/config/supervised_config.py
+++ b/flexml/config/supervised_config.py
@@ -25,7 +25,7 @@ TUNING_METRIC_TRANSFORMATIONS = {
         'ROC-AUC': 'roc_auc'
     },
 
-    "reverse_signed_eval_metrics": ['MAE', 'MSE', 'RMSE']
+    "reverse_signed_eval_metrics": ['MAE','MSE', 'RMSE', 'MAPE']
     # These metrics are used in negative form for optimization processes, so we need to reverse the sign later, e.g. from -0.42 to 0.42
 }
 


### PR DESCRIPTION
### Explanation

Revised reverse_signed_eval_metrics list in supervised_config.py. Added 'MAPE' [#99b4ba6](https://github.com/ozguraslank/flexml/commit/99b4ba6e9cef3ce27e8c8fdadc066c8abd961978)