### PR TITLE
Error fixes on Optuna module and start_experiment of SupervisedBase

### DIFF
--- a/flexml/_model_tuner.py
+++ b/flexml/_model_tuner.py
@@ -8,6 +8,7 @@ from sklearn.pipeline import Pipeline
 from flexml.config import TUNING_METRIC_TRANSFORMATIONS
 from flexml.logger import get_logger
 from flexml.helpers import evaluate_model_perf
+from copy import deepcopy
 
 
 class ModelTuner:
@@ -505,6 +506,9 @@ class ModelTuner:
         study_direction = "maximize" if eval_metric in ['R2', 'Accuracy', 'Precision', 'Recall', 'F1 Score', 'ROC-AUC'] else "minimize"
 
         def objective(trial):
+            # Create a copy of feature engineer for this trial
+            feature_engineer_copy = deepcopy(feature_engineer)
+            
             # Generate parameters for the trial
             params = model.get_params()
             for param_name, param_values in param_grid.items():
@@ -526,10 +530,10 @@ class ModelTuner:
                 train_data = pd.concat([self.X.iloc[train_idx], self.y.iloc[train_idx]], axis=1)
                 test_data = pd.concat([self.X.iloc[test_idx], self.y.iloc[test_idx]], axis=1)
 
-                feature_engineer.setup(data=train_data)
-            
-                X_train, y_train = feature_engineer.fit_transform()
-                X_test, y_test = feature_engineer.transform(test_data=test_data, y_included=True)
+                # Use the copied feature engineer
+                feature_engineer_copy.setup(data=train_data)
+                X_train, y_train = feature_engineer_copy.fit_transform()
+                X_test, y_test = feature_engineer_copy.transform(test_data=test_data, y_included=True)
 
                 test_model = type(model)()
                 test_model.set_params(**params)

--- a/flexml/structures/supervised_base.py
+++ b/flexml/structures/supervised_base.py
@@ -471,8 +471,23 @@ class SupervisedBase:
 
         with tqdm(total=total_iterations, desc="INFO | Training Progress", bar_format="{desc}:  | {bar} | {percentage:.0f}%") as pbar:
             for train_idx, test_idx in cv_splits_copy:
-                train_data = pd.concat([self.X.iloc[train_idx], self.y.iloc[train_idx]], axis=1)
-                test_data = pd.concat([self.X.iloc[test_idx], self.y.iloc[test_idx]], axis=1)
+                try:
+                    # Attempt to use as positional indices (For Cross-Validation splits)
+                    train_labels = self.X.index[train_idx]
+                    test_labels = self.X.index[test_idx]
+                except IndexError: # For holdout validation
+                    # Fallback to using as label-based indices
+                    train_labels = train_idx
+                    test_labels = test_idx
+                
+                train_data = pd.concat([
+                    self.X.loc[train_labels], 
+                    self.y.loc[train_labels]
+                ], axis=1)
+                test_data = pd.concat([
+                    self.X.loc[test_labels],
+                    self.y.loc[test_labels]
+                ], axis=1)
                 
                 self.feature_engineer.setup(data=train_data)
                 


### PR DESCRIPTION
### Explanation

**Solved parallelism error happens in Optuna, during feature_engineering transformations** [#f62b434](https://github.com/ozguraslank/flexml/commit/f62b434f3e6dbd5406d4b0bb52d829e1fd57fad1)
If `n_jobs` is bigger than 1 which enables parallelism, since same `feature_engineer` object is used for all transformations among cv splits and the feature engineer object plays with columns, It was giving error since multiple different things were being done. Created deep copy of feature engineer object in the objective function of Optuna to solve the problem.

**Avoided index mismatch happens in holdout validation when data's index is mixed** [#050d6ea](https://github.com/ozguraslank/flexml/commit/050d6ea98a5f0d19e953d8ea8e1b547da7b10c03)
`start_experiment() `was raising error when `cv_method` is '`holdout`' and given dataframe's index is not orderly. Due to pandas index mismatches. Holdout used label-based indices while CV used positional indices, causing loc/iloc conflicts.