### PR TITLE
Improved unit test coverage of the functions at flexml/helpers

### DIFF
--- a/flexml/helpers/cross_validation.py
+++ b/flexml/helpers/cross_validation.py
@@ -151,7 +151,3 @@ def get_cv_splits(
                 stratify=y_array if cv_method == "stratified_kfold" else None
         )
         return [(train_index, test_index)]
-
-    else: # Default
-        splitter = KFold(n_splits=5, random_state=random_state, shuffle=shuffle)
-        return splitter.split(df)

--- a/flexml/helpers/validators.py
+++ b/flexml/helpers/validators.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from typing import Optional, List, Any
+from typing import Optional, List
 from flexml.config import EVALUATION_METRICS, FEATURE_ENGINEERING_METHODS, CROSS_VALIDATION_METHODS
 from flexml.logger import get_logger
 import re
@@ -76,13 +76,13 @@ def eval_metric_checker(
     
     return eval_metric
 
-def random_state_checker(random_state: Any) -> int:
+def random_state_checker(random_state: Optional[int] = None) -> int:
     """
     Validates the random_state parameter
 
     Parameters
     ----------
-    random_state : Any
+    random_state : int, optional (default=None)
         Random state value
 
     Returns

--- a/flexml/helpers/validators.py
+++ b/flexml/helpers/validators.py
@@ -140,6 +140,11 @@ def cross_validation_checker(
     """
     logger = get_logger(__name__, "PROD", False)
 
+    if ml_task_type is not None and ml_task_type not in ['Regression', 'Classification']:
+        error_msg = f"ml_task_type should be 'Regression' or 'Classification', got {ml_task_type}"
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+
     if available_cv_methods is None:
         if ml_task_type is not None:
             available_cv_methods = CROSS_VALIDATION_METHODS[ml_task_type]
@@ -152,10 +157,7 @@ def cross_validation_checker(
                 cv_method = 'kfold'
             elif ml_task_type == "Classification":
                 cv_method = 'stratified_kfold'
-            else:
-                error_msg = f"ml_task_type should be 'Regression' or 'Classification', got {ml_task_type}"
-                logger.error(error_msg)
-                raise ValueError(error_msg)
+
     else:
         cv_method = cv_method.lower()
         if available_cv_methods.get(cv_method) is None:

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -1,11 +1,12 @@
 import unittest
-from typing import Optional
+from typing import Optional, Union
+from types import GeneratorType
 import numpy as np
 from parameterized import parameterized
 from sklearn.datasets import load_breast_cancer, load_diabetes
 from flexml.logger import get_logger
 from flexml import Regression, Classification
-from flexml.helpers import cross_validation_checker
+from flexml.helpers import cross_validation_checker, get_cv_splits
 
 import warnings
 warnings.filterwarnings("ignore")
@@ -84,19 +85,49 @@ class TestCrossValidation(unittest.TestCase):
         self.assertIsInstance(predictions, np.ndarray)
 
     @parameterized.expand([
-        ("X", {}, ValueError),  # Random cv_method is given
-        ("kfold", {"n_splits": 1}, ValueError),  # n_folds is not an integer >= 2
-        ("holdout", {"test_size": 1.1}, ValueError),  # test_size is not a float between 0 and 1
-        ("group_kfold", {"n_splits": 3, "groups_col": "X"}, ValueError),  # groups_col is not a column in the DataFrame
-        ("group_shuffle_split", {"n_splits": 3}, ValueError),  # groups_col is not provided
-        ("group_kfold", {"n_splits": 3, "test_size": 0.25}, ValueError),  # groups_col is not provided
+        ("test_invalid_cv_method", "X", {}, ValueError),
+        ("test_invalid_n_folds", "kfold", {"n_folds": 1}, ValueError),
+        ("test_invalid_test_size", "holdout", {"test_size": 1.1}, ValueError),
+        ("test_invalid_groups_col", "group_kfold", {"n_folds": 3, "groups_col": "X"}, ValueError),
+        ("test_missing_groups_col_for_group_shuffle_split", "group_shuffle_split", {"n_folds": 3}, ValueError),
+        ("test_missing_groups_col_for_group_kfold", "group_kfold", {"n_folds": 3, "test_size": 0.25}, ValueError),
+        ("test_default_cv_for_classification", None, {"ml_task_type": "Classification"}, "stratified_kfold"),
+        ("test_invalid_ml_task_type", "kfold", {"ml_task_type": "X"}, ValueError), 
+        ("test_normalize_stratified_kfold_name", "stratifiedkfold", {"ml_task_type": "Classification"}, "stratified_kfold") 
     ])
-    def test_required_errors(self, cv_method: str, params: dict, expected_error: Exception):
-        with self.assertRaises(expected_error):
-            cross_validation_checker(
+    def test_expected_results(self, test_name: str, cv_method: str, params: dict, expected_result: Union[str, Exception]):
+        if isinstance(expected_result, type) and issubclass(expected_result, BaseException):  # Your IDE might say 'code is not reachable' here, but Its
+            with self.assertRaises(expected_result):
+                cross_validation_checker(
+                    df=self.regression_data,
+                    cv_method=cv_method,
+                    **params
+                )
+        else:
+            result = cross_validation_checker(
                 df=self.regression_data,
                 cv_method=cv_method,
-                n_folds=params.get("n_splits"),
-                test_size=params.get("test_size"),
-                groups_col=params.get("groups_col")
+                **params
             )
+            self.assertEqual(result, expected_result)
+
+    @parameterized.expand([
+        ("test_cv_with_none_nfolds", "kfold", {"n_folds": None}, GeneratorType),
+        ("test_stratified_without_y_array", "stratified_kfold", {}, ValueError),
+        ("test_holdout_returns_generator", "holdout", {"test_size": 0.25}, list)
+    ])
+    def test_get_cv_splits(self, test_name: str, cv_method: str, params: dict, expected_result: Union[str, Exception]):
+        if issubclass(expected_result, BaseException): # Your IDE might say 'code is not reachable' here, but Its
+            with self.assertRaises(expected_result):
+                get_cv_splits(
+                    df=self.regression_data,
+                    cv_method=cv_method,
+                    **params
+                )
+        else:
+            splits = get_cv_splits(
+                df=self.regression_data,
+                cv_method=cv_method,
+                **params
+            )
+            self.assertIsInstance(splits, expected_result)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,388 @@
+import unittest
+import pandas as pd
+import numpy as np
+from parameterized import parameterized
+from flexml.helpers import validate_inputs, eval_metric_checker, random_state_checker
+import warnings
+warnings.filterwarnings("ignore")
+
+
+class TestHelpers(unittest.TestCase):
+    """
+    Test cases for the feature engineering pipeline in the Classification class
+    """
+    np.random.seed(42)
+    n_rows = 100
+
+    df = pd.DataFrame({
+        'id': range(1, n_rows + 1),
+        'category_default': np.random.choice(['A', 'B', 'C'], n_rows),    
+        'value_default': np.random.normal(100, 15, n_rows),
+        'status': np.random.choice(['Active', 'Pending', 'Closed'], n_rows),
+        'priority': np.random.choice(['High', 'Medium', 'Low'], n_rows),
+        'score': np.random.randint(0, 100, n_rows),
+        'amount': np.random.uniform(10, 1000, n_rows),
+        'target': np.random.choice([0, 1], n_rows)
+    })
+
+    # This will create artificial null values within dataframe
+    for column in df.columns:
+        if column not in ['id', 'target']:
+            mask = np.random.random(n_rows) < 0.2
+            df.loc[mask, column] = np.nan
+
+    encoding_methods = ['label_encoder', 'onehot_encoder', 'ordinal_encoder']
+    imputation_methods = ['mean', 'median', 'mode', 'constant', 'drop']
+    normalization_methods = ['standard_scaler', 'minmax_scaler', 'robust_scaler', 'quantile_transformer', 'maxabs_scaler', 'normalize_scaler']
+
+
+    @parameterized.expand([
+        # Basic validation errors
+        (
+            "target_in_drop_columns", 
+            {"drop_columns": ["target"]}, 
+            ValueError, 
+            "target column 'target' cannot be in the drop_columns list"
+        ),
+
+        (
+            "no_features_after_drop", 
+            {"drop_columns": ["category_default", "value_default", "status", "priority", "score", "amount", "id"]}, 
+            ValueError, 
+            "After dropping columns, only {'target'} remain"
+        ),
+
+        # Imputation method errors
+        (
+            "invalid_cat_imputation", 
+            {"categorical_imputation_method": "invalid"}, 
+            ValueError,
+            "categorical_imputation_method 'invalid' is not valid"
+        ),
+
+        (
+            "invalid_num_imputation", 
+            {"numerical_imputation_method": "invalid"}, 
+            ValueError,
+            "numerical_imputation_method 'invalid' is not valid"
+        ),
+
+        # Column imputation map errors
+        (
+            "column_imputation_invalid_column", 
+            {"column_imputation_map": {"nonexistent_column": "mean"}}, 
+            ValueError,
+            "column 'nonexistent_column' in column_imputation_map is not in the data"
+        ),
+
+        (
+            "column_imputation_invalid_numeric_method", 
+            {"column_imputation_map": {"value_default": "invalid"}}, 
+            ValueError,
+            "numeric imputation method 'invalid' for column 'value_default' is not valid"
+        ),
+
+        (
+            "column_imputation_invalid_categorical_method", 
+            {"column_imputation_map": {"category_default": "invalid"}}, 
+            ValueError,
+            "categorical imputation method 'invalid' for column 'category_default' is not valid"
+        ),
+
+        # Constant type errors
+        (
+            "invalid_numerical_constant", 
+            {"numerical_imputation_constant": "invalid"}, 
+            ValueError,
+            "numerical_imputation_constant should be a number"
+        ),
+
+        (
+            "invalid_categorical_constant", 
+            {"categorical_imputation_constant": 123}, 
+            ValueError,
+            "categorical_imputation_constant should be a string"
+        ),
+
+        # Encoding method errors
+        (
+            "invalid_encoding_method", 
+            {"encoding_method": "invalid_encoder"}, 
+            ValueError,
+            "encoding_method 'invalid_encoder' is not valid"
+        ),
+
+        (
+            "invalid_onehot_limit", 
+            {"onehot_limit": -5}, 
+            ValueError,
+            "onehot_limit should be a positive integer"
+        ),
+
+        # Encoding method map errors
+        (
+            "encoding_map_invalid_column", 
+            {"encoding_method_map": {"nonexistent_column": "label_encoder"}}, 
+            ValueError,
+            "column 'nonexistent_column' in encoding_method_map is not in the data"
+        ),
+
+        (
+            "encoding_map_dropped_column", 
+            {"drop_columns": ["category_default"], "encoding_method_map": {"category_default": "label_encoder"}}, 
+            ValueError,
+            "column 'category_default' in encoding_method_map is in drop_columns"
+        ),
+
+        (
+            "encoding_map_invalid_method", 
+            {"encoding_method_map": {"category_default": "invalid"}}, 
+            ValueError,
+            "encoding method 'invalid' for column 'category_default' is not valid"
+        ),
+
+        # Ordinal encoding errors
+        (
+            "missing_ordinal_map", 
+            {"encoding_method": "ordinal_encoder"}, 
+            ValueError,
+            "Ordinal encoding is selected but no ordinal_encode_map is provided"
+        ),
+
+        (
+            "missing_column_ordinal_map", 
+            {"encoding_method": "ordinal_encoder", "ordinal_encode_map": {}}, 
+            ValueError,
+            "Ordinal encoding is selected for column 'category_default' but no ordinal_encode_map is provided"
+        ),
+
+        (
+            "mismatched_ordinal_values", 
+            {"encoding_method": "ordinal_encoder", 
+             "ordinal_encode_map": {
+                 "category_default": ["X", "Y", "Z"],
+                 "status": ["Active", "Pending", "Closed"],
+                 "priority": ["Low", "Medium", "High"]}}, 
+            ValueError,
+            "Distinct values in column 'category_default' do not match"
+        ),
+
+        (
+            "extra_columns_ordinal_map", 
+            {"encoding_method": "ordinal_encoder", 
+             "ordinal_encode_map": {
+                 "category_default": ["A", "B", "C"],
+                 "status": ["Active", "Pending", "Closed"],
+                 "priority": ["Low", "Medium", "High"],
+                 "extra_column": ["X", "Y", "Z"]}}, 
+            ValueError,
+            "Ordinal_encode_map includes extra columns not in the categorical columns"
+        ),
+
+        # Normalization errors
+        (
+            "invalid_normalization", 
+            {"normalize": "invalid_scaler"}, 
+            ValueError,
+            "normalize method 'invalid_scaler' is not valid"
+        ),
+
+        # Drop columns validation
+        (
+            "drop_column_not_in_data", 
+            {"drop_columns": ["nonexistent_column"]}, 
+            ValueError,
+            "column 'nonexistent_column' in drop_columns is not in the data"
+        ),
+
+        # Ordinal encoding in method map errors
+        (
+            "missing_ordinal_map_in_method_map", 
+            {"encoding_method_map": {"category_default": "ordinal_encoder"}}, 
+            ValueError,
+            "Ordinal encoding is selected for column 'category_default' but no ordinal_encode_map is provided"
+        ),
+
+        (
+            "missing_column_ordinal_map_in_method_map", 
+            {"encoding_method_map": {"category_default": "ordinal_encoder"},
+             "ordinal_encode_map": {}}, 
+            ValueError,
+            "Ordinal encoding is selected for column 'category_default' but no ordinal_encode_map is provided"
+        ),
+
+        (
+            "mismatched_ordinal_values_in_method_map", 
+            {"encoding_method_map": {
+                 "category_default": "ordinal_encoder",
+                 "status": "label_encoder",
+                 "priority": "label_encoder"
+             },
+             "ordinal_encode_map": {
+                 "category_default": ["X", "Y", "Z"]
+             }}, 
+            ValueError,
+            "Unique values in 'category_default' do not match with the ones given in ordinal_encode_map"
+        ),
+
+        (
+            "extra_columns_ordinal_map_in_method_map", 
+            {"encoding_method_map": {
+                 "category_default": "ordinal_encoder"
+             },
+             "ordinal_encode_map": {
+                 "category_default": ["A", "B", "C"],
+                 "extra_column": ["X", "Y", "Z"]
+             }}, 
+            ValueError,
+            "Ordinal_encode_map includes extra columns not specified for ordinal encoding"
+        ),
+    ])
+    def test_validate_inputs_errors(self, test_name, params, expected_error, expected_message):
+        """Test validate_inputs exception raising for invalid parameters"""
+        with self.assertRaisesRegex(expected_error, expected_message):
+            validate_inputs(
+                data=self.df,
+                target_col='target',
+                **params
+            )
+
+    @parameterized.expand([
+        # Default behavior tests
+        (
+            "regression_default",
+            {"ml_task_type": "Regression", "eval_metric": None},
+            "R2",
+            None
+        ),
+        (
+            "classification_default",
+            {"ml_task_type": "Classification", "eval_metric": None},
+            "Accuracy",
+            None
+        ),
+
+        # Regression metric tests
+        (
+            "regression_valid_lowercase",
+            {"ml_task_type": "Regression", "eval_metric": "mae"},
+            "MAE",
+            None
+        ),
+        (
+            "regression_valid_uppercase",
+            {"ml_task_type": "Regression", "eval_metric": "RMSE"},
+            "RMSE",
+            None
+        ),
+        (
+            "regression_invalid_metric",
+            {"ml_task_type": "Regression", "eval_metric": "invalid"},
+            None,
+            ValueError
+        ),
+
+        # Classification metric tests
+        (
+            "classification_valid_exact",
+            {"ml_task_type": "Classification", "eval_metric": "Accuracy"},
+            "Accuracy",
+            None
+        ),
+        (
+            "classification_valid_flexible",
+            {"ml_task_type": "Classification", "eval_metric": "roc-auc"},
+            "ROC-AUC",
+            None
+        ),
+        (
+            "classification_valid_no_special",
+            {"ml_task_type": "Classification", "eval_metric": "rocauc"},
+            "ROC-AUC",
+            None
+        ),
+        (
+            "classification_invalid_metric",
+            {"ml_task_type": "Classification", "eval_metric": "invalid"},
+            None,
+            ValueError
+        ),
+
+        # Custom metrics list tests
+        (
+            "custom_metrics_valid_classification",
+            {
+                "ml_task_type": "Classification",
+                "eval_metric": "F1 Score",
+                "all_evaluation_metrics": None,
+                "default_evaluation_metric": None
+            },
+            "F1 Score",
+            None
+        ),
+
+        (
+            "custom_metrics_valid_regression",
+            {
+                "ml_task_type": "Regression",
+                "eval_metric": "MAE",
+                "all_evaluation_metrics": None,
+                "default_evaluation_metric": None
+            },
+            "MAE",
+            None
+        ),
+
+    ])
+    def test_eval_metric_checker(self, test_name, params, expected_result, expected_error):
+        """Test eval_metric_checker validation"""
+        if expected_error:
+            with self.assertRaises(expected_error):
+                eval_metric_checker(**params)
+        else:
+            result = eval_metric_checker(**params)
+            self.assertEqual(result, expected_result)
+
+    @parameterized.expand([
+        # Valid cases
+        (
+            "none_value",
+            None,
+            None,
+            None
+        ),
+        (
+            "zero_value",
+            0,
+            0,
+            None
+        ),
+        (
+            "positive_integer",
+            42,
+            42,
+            None
+        ),
+
+        # Invalid cases
+        (
+            "negative_integer",
+            -1,
+            None,
+            ValueError
+        ),
+        (
+            "float_value",
+            42.0,
+            None,
+            ValueError
+        )
+    ])
+    def test_random_state_checker(self, test_name, input_value, expected_result, expected_error):
+        """Test random_state_checker validation"""
+        if expected_error:
+            with self.assertRaises(expected_error):
+                random_state_checker(input_value)
+        else:
+            result = random_state_checker(input_value)
+            self.assertEqual(result, expected_result)


### PR DESCRIPTION
### Explanation

Related to #40 

Improving `flexml/helpers` functions for better coverage by adding error raiser unit tests to catch required errors.
Added a new unittest named `test_helpers` for this.

Also, revised `random_state` param's type hint as from `Any` to `Optional[int]` since Its like this in the whole library.
