### PR TITLE
Error fix / Added 'category' dtype to categorical data check in encoders

### DIFF
--- a/flexml/_feature_engineer.py
+++ b/flexml/_feature_engineer.py
@@ -495,7 +495,7 @@ class FeatureEngineering:
         
         # Process if target column is categorical
         target_data = self.data[self.target_col]
-        if target_data.dtype == 'object':
+        if target_data.dtype in ['object', 'category']:
             target_data = self.target_encoder.fit_transform(target_data)
 
         processed_features[self.target_col] = target_data
@@ -534,7 +534,7 @@ class FeatureEngineering:
         # Add target column if it exists in test data
         if self.target_col in test_data.columns:
             target_data = test_data[self.target_col]
-            if target_data.dtype == 'object':
+            if target_data.dtype in ['object', 'category']:
                 target_data = self.target_encoder.transform(target_data)
             processed_test_features[self.target_col] = target_data
 

--- a/flexml/structures/supervised_base.py
+++ b/flexml/structures/supervised_base.py
@@ -1326,7 +1326,7 @@ class SupervisedBase:
 
         # Create the ModelTuner object If It's not created before, avoid creating it everytime tune_model() function is called
         if not hasattr(self, 'model_tuner'):
-            if self.__ML_TASK_TYPE == 'Classification' and self.y.dtype == 'object':
+            if self.__ML_TASK_TYPE == 'Classification' and self.y.dtype in ['object', 'category']:
                 y_encoded = pd.Series(self.feature_engineer.target_encoder.fit_transform(self.y), name=self.target_col)
                 y_encoded.index = self.y.index
             else:


### PR DESCRIPTION
### Explanation

When target column's dtype is 'categorical', FlexML was not able to detect it and apply encoding to it.

Added 'category' value to corresponding checks