### PR TITLE
Resolved Colab Cronic Pip Version Bug

### DIFF
--- a/flexml/__init__.py
+++ b/flexml/__init__.py
@@ -2,6 +2,9 @@
 FlexML: Easy-to-use and flexible AutoML library for Python
 """
 
+from flexml.helpers.tools import check_numpy_dtype_error
+check_numpy_dtype_error() # Check cronic Colab version issue
+
 from .regression import Regression
 from .classification import Classification
 

--- a/flexml/helpers/__init__.py
+++ b/flexml/helpers/__init__.py
@@ -1,3 +1,6 @@
+from flexml.helpers.tools import check_numpy_dtype_error
+check_numpy_dtype_error() # Check cronic Colab version issue
+
 from flexml.helpers.validators import (
     eval_metric_checker,
     random_state_checker,

--- a/flexml/helpers/tools.py
+++ b/flexml/helpers/tools.py
@@ -1,4 +1,5 @@
 from IPython import get_ipython
+from flexml.logger import get_logger
 
 
 def is_interactive_notebook():
@@ -13,3 +14,26 @@ def is_interactive_notebook():
     except:
         # get_ipython() will not be defined in non-interactive environments
         return False
+    
+
+def check_numpy_dtype_error():
+    """
+    Checks if the numpy version is compatible with the pandas version in Colab
+    """
+    logger = get_logger(__name__, "PROD")
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell != "Shell": # If environment is not Colab, no need for this check since It only happens in Colab
+            return
+
+        import pandas
+    except ValueError as e: # Catch ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
+        if 'numpy.dtype size changed' in str(e):
+            logger.warning("Colab has cronic version issue, restarting the kernel... (details: https://shorturl.at/ZMJBh)")
+            try:
+                import os
+                os.kill(os.getpid(), 9)
+            except: # If it fails, try to exit the program. 
+                exit()
+        else:
+            raise e

--- a/flexml/structures/supervised_base.py
+++ b/flexml/structures/supervised_base.py
@@ -536,7 +536,7 @@ class SupervisedBase:
 
         # Train only the models that haven't been trained yet
         if not reset_the_experiment and quick_to_wide_flag: 
-            self.__existing_model_names = self._model_stats_df['Model Name'].unique() if self._model_stats_df is not None else []
+            self.__existing_model_names = list(self._model_stats_df['Model Name'].unique()) if self._model_stats_df is not None else []
         else:
             self.__model_training_info = []
             self._model_stats_df = None


### PR DESCRIPTION
### Explanation

Colab installs the required libraries during pip install flexml but still uses the old versions. Due to this bug, Pandas raises numpy dtype changed error which is a popular version problem of pandas and numpy If suitable versions are not given.

The solution is basically restarting the Colab session but user shouldn't do this process everytime he/she uses Colab.

Therefore, added a check that imports pandas and checks If this error type raises, If raises, It crashes Colab session and forces to restart. 

----

Also, realized a small mistake in `supervised_base.py`: <br>
`self.__existing_model_names` variable becomes numpy array instead of list in a case in `start_experiment()`, this raises error when `tune_model()` is called, numpy array doesn't have 'append' operation thing.