### PR TITLE
Revised Optuna tuning structure & Typing hint revise for CV param

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+  
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/flexml/_model_tuner.py
+++ b/flexml/_model_tuner.py
@@ -357,7 +357,7 @@ class ModelTuner:
             self.logger.error(f"Error while tuning the model with GridSearchCV, Error: {e}")
             return None
     
-    def random_search(
+    def randomized_search(
         self,
         pipeline: Pipeline,
         param_grid: dict,
@@ -368,7 +368,7 @@ class ModelTuner:
         verbose: int = 0
     ) -> Optional[dict]:
         """
-        Implements random search hyperparameter optimization on the giveen machine learning model
+        Implements randomized search hyperparameter optimization on the giveen machine learning model
 
         Parameters
         ----------

--- a/flexml/_model_tuner.py
+++ b/flexml/_model_tuner.py
@@ -234,7 +234,7 @@ class ModelTuner:
         pipeline: Pipeline,
         param_grid: dict,
         eval_metric: str,
-        cv: object,
+        cv: list,
         n_jobs: int = -1,
         verbose: int = 0
     ) -> Optional[dict]:
@@ -270,8 +270,10 @@ class ModelTuner:
             
             * 'F1 Score' for F1 score
 
-        cv : object
-            A cross-validation splitter object (e.g., KFold, StratifiedKFold, etc.)
+        cv : list of tuples
+            A list of (train_idx, test_idx) tuples where each tuple contains numpy arrays of indices
+            for the training and test sets for that fold. For example:
+            [(array([1,2,4,...]), array([0,3,6,...])), ...]
 
         n_jobs : int (default=-1)
             The number of parallel jobs to run. The default is -1.
@@ -312,7 +314,7 @@ class ModelTuner:
             
             # Calculate total fits
             total_params = len(ParameterGrid(param_grid))
-            n_splits = len(list(cv))
+            n_splits = len(cv)
             total_fits = total_params * n_splits
 
             # Create GridSearchCV object
@@ -362,7 +364,7 @@ class ModelTuner:
         pipeline: Pipeline,
         param_grid: dict,
         eval_metric: str,
-        cv: object,
+        cv: list,
         n_iter: int = 10,
         n_jobs: int = -1,
         verbose: int = 0
@@ -399,8 +401,10 @@ class ModelTuner:
             
             * 'F1 Score' for F1 score
 
-        cv : object
-            A cross-validation splitter object (e.g., KFold, StratifiedKFold, etc.)
+        cv : list of tuples
+            A list of (train_idx, test_idx) tuples where each tuple contains numpy arrays of indices
+            for the training and test sets for that fold. For example:
+            [(array([1,2,4,...]), array([0,3,6,...])), ...]
 
         n_iter : int, optional (default=10)
             The number of trials. The default is 10
@@ -431,7 +435,7 @@ class ModelTuner:
         t_start = time()
         
         # Calculate total fits
-        n_splits = len(list(cv))
+        n_splits = len(cv)
         total_fits = n_iter * n_splits
 
         # Create RandomizedSearchCV object
@@ -480,7 +484,7 @@ class ModelTuner:
         pipeline: Pipeline,
         param_grid: dict,
         eval_metric: str,
-        cv: object,
+        cv: list,
         n_iter: int = 10,
         timeout: Optional[int] = None,
         n_jobs: int = -1,
@@ -518,8 +522,10 @@ class ModelTuner:
             
             * 'F1 Score' for F1 score
 
-        cv : object
-            A cross-validation splitter object (e.g., KFold, StratifiedKFold, etc.)
+        cv : list of tuples
+            A list of (train_idx, test_idx) tuples where each tuple contains numpy arrays of indices
+            for the training and test sets for that fold. For example:
+            [(array([1,2,4,...]), array([0,3,6,...])), ...]
 
         n_iter : int, optional (default=10)
             The number of trials. The default is 10

--- a/flexml/structures/supervised_base.py
+++ b/flexml/structures/supervised_base.py
@@ -1518,7 +1518,7 @@ class SupervisedBase:
             )
             
         elif tuning_method == "randomized_search":
-            tuning_result = self.model_tuner.random_search(
+            tuning_result = self.model_tuner.randomized_search(
                 pipeline=pipeline,
                 param_grid=param_grid,      
                 eval_metric=eval_metric,

--- a/flexml/structures/supervised_base.py
+++ b/flexml/structures/supervised_base.py
@@ -1530,8 +1530,7 @@ class SupervisedBase:
                 
         elif tuning_method == "optuna":
             tuning_result = self.model_tuner.optuna_search(
-                model=model,
-                feature_engineer=self.feature_engineer,
+                pipeline=pipeline,
                 param_grid=param_grid,
                 eval_metric=eval_metric,
                 cv=cv_obj,


### PR DESCRIPTION
### Explanation

* Updated `optuna_search()` structure to be same with other tunings, It will use `pipeline` object instead of `model` + `feature_engineer` [#db87768](https://github.com/ozguraslank/flexml/commit/db87768dc074adcb414e90b8ae8c59fd90e562f0)
* Renamed `ModelTuner` func to correct version `random_search()` to `randomized_search()` [7821c97](https://github.com/ozguraslank/flexml/commit/7821c97d5a8dc2159a214a8a7341ffed46cfa3ae)
* Revised `cv` related typing hint and func docs [#e06f42d](https://github.com/ozguraslank/flexml/commit/e06f42d74e667a4aff862b9e96ef26771dd6c9c9)

----
**Extra:** CodeCov raised an error while uploading the results to the cloud.
Solved via: https://stackoverflow.com/questions/72504998/unable-to-get-actions-id-token-request-url-env-variable