### PR TITLE
Error fix / Avoid shared pipeline state between Optuna trials during parallelization

### DIFF
--- a/flexml/_model_tuner.py
+++ b/flexml/_model_tuner.py
@@ -601,7 +601,13 @@ class ModelTuner:
                     info_msg = f"{param_name} parameter is not added to tuning since its type is not supported by Optuna."
                     self.logger.info(info_msg)
 
-            new_pipeline = Pipeline(steps=pipeline.steps[:-1] + [('model', clone(pipeline.named_steps['model']).set_params(**params))]) # Remove the old model from the pipeline and add the new one
+            # Clone the entire pipeline and its steps to avoid shared state between trials
+            preprocessing_steps = [(name, clone(step)) for name, step in pipeline.steps[:-1]]
+            new_pipeline = Pipeline(
+                steps=preprocessing_steps + [
+                    ('model', clone(pipeline.named_steps['model']).set_params(**params))
+                ]
+            )
 
             # Perform cross-validation and calculate the score
             scores = []


### PR DESCRIPTION
### Explanation

The error occurred because different Optuna trials were sharing same pipeline state through the pipeline's preprocessing steps. Even though Optuna was creating new models, same preprocessing components (like transformers) were being reused between trials and folds.

**Key Insights:**
* **Stateful Preprocessing:** Many sklearn transformers (like OneHotEncoder, StandardScaler) maintain internal state from fitting
* **Parallel Execution:** When using `n_jobs` > 1, multiple trials run simultaneously and might:
    - Overwrite each other's transformer states
    - Create inconsistent feature name mappings
* **Pipeline Reference Sharing:** The old code only cloned the model, not the preprocessing steps